### PR TITLE
Remove jsdom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
+  - 0.10
+  - 0.12
+  - 4.2

--- a/lib/syntax.js
+++ b/lib/syntax.js
@@ -1,14 +1,5 @@
 var vm = require("vm");
 var jsp = require("uglify-js").parser;
-var jsdom;
-
-try {
-    jsdom = require("jsdom").jsdom;
-} catch (e) {
-    // No worries, jsdom is optional
-    jsdom = function () { return {}; };
-}
-
 var refErrRegExp = /ReferenceError: (.*) is not defined/;
 
 function getType(error) {
@@ -42,15 +33,16 @@ function prepareResults(error, script, fileName) {
 }
 
 function createContext() {
-    var markup = "<!DOCTYPE html><html><head></head><body></body></html>";
-    var dom = jsdom(markup);
-
     var context = {
         setTimeout: setTimeout,
         setInterval: setInterval,
         clearTimeout: clearTimeout,
         clearInterval: clearInterval,
-        window: dom.createWindow && dom.createWindow()
+        window: {
+            document : {
+                createElement: function(){}
+            }
+        }
     };
 
     if (context.window) {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "dependencies": {
         "uglify-js": "~1.2.5"
     },
-    "optionalDependencies": {
-        "jsdom": "~0.10"
-    },
     "devDependencies": {
         "sinon": "*",
         "referee": "*",

--- a/test/syntax-test.js
+++ b/test/syntax-test.js
@@ -3,11 +3,6 @@ var referee = require("referee");
 var assert = referee.assert;
 var refute = referee.refute;
 var syntax = require("../lib/syntax");
-var jsdom;
-
-try {
-    jsdom = require("jsdom");
-} catch (e) {}
 
 testCase("Syntax", {
     "passes syntactically valid code": function () {
@@ -62,18 +57,6 @@ testCase("Syntax", {
         var checker = syntax.configure();
         checker.check("jQuery = function () {};");
         assert(checker.check("var a = jQuery('div');").ok);
-    },
-
-    "when jsdom is available": {
-        requiresSupportFor: { "jsdom": typeof jsdom !== "undefined" },
-
-        "does not recognize undefined globals": function () {
-            var checker = syntax.configure();
-            checker.check("jQuery = function () {};");
-            var result = checker.check("var a = $('div');");
-            refute(result.ok, JSON.stringify(result));
-            assert.equals(result.errors[0].type, syntax.REFERENCE_ERROR);
-        }
     },
 
     "ignores reference errors": function () {


### PR DESCRIPTION
This is part of an attempt at removing `jsdom` from Buster, in order to make installation less likely to fail.

See: https://github.com/busterjs/buster/issues/456
